### PR TITLE
Pin Netty to 4.2.15.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 // constraintene i BOM-en direkte, slik at GitHub Dependency Graph
 // rapporterer riktige (oppgraderte) versjoner.
 extra["tomcat.version"] = "11.0.22" // CVE-2026-41284, CVE-2026-43513, CVE-2026-42498, CVE-2026-43512, CVE-2026-43515
-extra["netty.version"] = "4.2.13.Final" // CVE-2026-42579
+extra["netty.version"] = "4.2.15.Final" // CVE-2026-44249, CVE-2026-45416
 
 val toolsJacksonVersion = "3.1.3"
 val jacksonAnnotationVersion = "2.21"


### PR DESCRIPTION
Updates the Spring Boot BOM Netty override in build.gradle.kts so io.netty:netty-handler resolves to 4.2.15.Final.

Validation:
- ./gradlew dependencies --configuration runtimeClasspath
- ./gradlew dependencyInsight --dependency netty-handler --configuration runtimeClasspath
- ./gradlew build